### PR TITLE
Use 42 Runtime

### DIFF
--- a/dev.alextren.Spot.json
+++ b/dev.alextren.Spot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "dev.alextren.Spot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "41",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"
@@ -36,45 +36,6 @@
         "*.a"
     ],
     "modules": [
-        {
-            "name": "libadwaita",
-            "buildsystem": "meson",
-            "config-opts": [
-                "-Dexamples=false",
-                "-Dtests=false"
-            ],
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://gitlab.gnome.org/GNOME/libadwaita.git",
-                    "branch": "1.0.0.alpha.4"
-                }
-            ],
-            "modules": [
-                {
-                    "name": "libsass",
-                    "buildsystem": "meson",
-                    "sources": [
-                        {
-                            "type": "git",
-                            "url": "https://github.com/lazka/libsass.git",
-                            "branch": "meson"
-                        }
-                    ]
-                },
-                {
-                    "name": "sassc",
-                    "buildsystem": "meson",
-                    "sources": [
-                        {
-                            "type": "git",
-                            "url": "https://github.com/lazka/sassc.git",
-                            "branch": "meson"
-                        }
-                    ]
-                }
-            ]
-        },
         {
             "name": "spot",
             "builddir": true,


### PR DESCRIPTION
Use GNOME 42 runtime since it's out now and remove libadwaita from the manifest.

Probably needs updating upstream as well.

