### PR TITLE
fix: miss gvfs permission

### DIFF
--- a/dev.alextren.Spot.json
+++ b/dev.alextren.Spot.json
@@ -15,7 +15,9 @@
         "--socket=pulseaudio",
         "--device=dri",
         "--talk-name=org.freedesktop.secrets",
-        "--own-name=org.mpris.MediaPlayer2.Spot"
+        "--own-name=org.mpris.MediaPlayer2.Spot",
+        "--talk-name=org.gtk.vfs.*",
+        "--filesystem=xdg-run/gvfsd"
     ],
     "build-options": {
         "append-path": "/usr/lib/sdk/rust-stable/bin",


### PR DESCRIPTION
There's an error message in the session bus log:

```
Filtering message due to arg0 org.gtk.vfs.Daemon, policy: 0 (required 2)
*HIDDEN* (ping)
B-1: <- org.freedesktop.DBus return from C10
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C11
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C12
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C13
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C14
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C15
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C16
*SKIPPED*
B-1: <- org.freedesktop.DBus return from C17
B-1: <- org.freedesktop.DBus return from C18
*REWRITTEN*
C19: -> org.freedesktop.DBus call org.freedesktop.DBus.GetNameOwner at /org/freedesktop/DBus
Filtering message due to arg0 org.gtk.vfs.Daemon, policy: 0 (required 1)
B-1: <- org.freedesktop.DBus return from C19
*REWRITTEN*
C20: -> org.gtk.vfs.Daemon call org.gtk.vfs.MountTracker.ListMountableInfo at /org/gtk/vfs/mounttracker
*HIDDEN* (ping)
B-1: <- org.freedesktop.DBus return from C20
*REWRITTEN*
```

According to [flatpak's documentation](https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access), typical GNOME and GTK applications should use:

```
--talk-name=org.gtk.vfs.*
--filesystem=xdg-run/gvfsd
```