### PR TITLE
Update GNOME runtime to version 47 

### DIFF
--- a/dev.alextren.Spot.json
+++ b/dev.alextren.Spot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "dev.alextren.Spot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"

--- a/dev.alextren.Spot.json
+++ b/dev.alextren.Spot.json
@@ -1,7 +1,7 @@
 {
     "app-id": "dev.alextren.Spot",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
GNOME runtime version 45 has reached EOL.

